### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/src/Data/DynamicState.hs
+++ b/src/Data/DynamicState.hs
@@ -29,11 +29,13 @@ newtype DynamicState = DynamicState { unDynamicState :: M.HashMap ConcreteTypeRe
 
 #if __GLASGOW_HASKELL__ >= 804
 instance Semigroup DynamicState where
-  (<>) = mappend
+  DynamicState a <> DynamicState b = DynamicState (a <> b)
 #endif
 
 instance Monoid DynamicState where
+#if !MIN_VERSION_base(4,11,0)
   mappend (DynamicState a) (DynamicState b) = DynamicState (mappend a b)
+#endif
   mempty = DynamicState mempty
 
 getDyn :: forall a. Typeable a => DynamicState -> Maybe a

--- a/src/Data/DynamicState/Serializable.hs
+++ b/src/Data/DynamicState/Serializable.hs
@@ -56,11 +56,13 @@ newtype DynamicState = DynamicState { unDynamicState :: M.HashMap ConcreteTypeRe
 
 #if __GLASGOW_HASKELL__ >= 804
 instance Semigroup DynamicState where
-  (<>) = mappend
+  DynamicState a <> DynamicState b = DynamicState (a <> b)
 #endif
 
 instance Monoid DynamicState where
+#if !MIN_VERSION_base(4,11,0)
   mappend (DynamicState a) (DynamicState b) = DynamicState (mappend a b)
+#endif
   mempty = DynamicState mempty
 
 -- | Get a value, inside a State-like monad specified by the first two functions


### PR DESCRIPTION
This appeases the -Wnoncanonical-monoid-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid